### PR TITLE
fix crash when n_samples % batch_size == 0

### DIFF
--- a/toponn/src/writer.rs
+++ b/toponn/src/writer.rs
@@ -180,9 +180,9 @@ impl Drop for HDF5Writer {
     fn drop(&mut self) {
         if self.batch_idx > 0 {
             self.write_batch().expect("Cannot write last batch");
-            self.file
-                .write("batches", self.batch + 1)
-                .expect("Cannot write last batch");
         }
+        self.file
+            .write("batches", self.batch)
+            .expect("Cannot write last batch");
     }
 }

--- a/toponn/src/writer.rs
+++ b/toponn/src/writer.rs
@@ -178,9 +178,11 @@ impl HDF5Writer {
 
 impl Drop for HDF5Writer {
     fn drop(&mut self) {
-        self.write_batch().expect("Cannot write last batch");
-        self.file
-            .write("batches", self.batch + 1)
-            .expect("Cannot write last batch");
+        if self.batch_idx > 0 {
+            self.write_batch().expect("Cannot write last batch");
+            self.file
+                .write("batches", self.batch + 1)
+                .expect("Cannot write last batch");
+        }
     }
 }

--- a/toponn/src/writer.rs
+++ b/toponn/src/writer.rs
@@ -180,9 +180,13 @@ impl Drop for HDF5Writer {
     fn drop(&mut self) {
         if self.batch_idx > 0 {
             self.write_batch().expect("Cannot write last batch");
+            self.file
+                .write("batches", self.batch + 1)
+                .expect("Cannot write last batch");
+        } else {
+            self.file
+                .write("batches", self.batch)
+                .expect("Cannot write last batch");
         }
-        self.file
-            .write("batches", self.batch)
-            .expect("Cannot write last batch");
     }
 }


### PR DESCRIPTION
This fixes a bug where the program crashes when `n_samples % batch_size == 0`.
If the `HD5Writer` is dropped after just having written a batch, it tries to write an empty batch thus resulting in a crash.