### PR TITLE
Factor out common model code to Model base class.

### DIFF
--- a/toponn-utils/tensorflow/config.py
+++ b/toponn-utils/tensorflow/config.py
@@ -3,6 +3,7 @@ from os import path
 
 class DefaultConfig:
     init_scale = 0.05
+    crf = False
     glu = False
     hidden_size = 50
     keep_prob = 0.85

--- a/toponn-utils/tensorflow/model.py
+++ b/toponn-utils/tensorflow/model.py
@@ -1,0 +1,116 @@
+import tensorflow as tf
+
+
+class Model:
+    def __init__(self, config, shapes):
+        self._config = config
+        self._shapes = shapes
+
+    def accuracy(self, prefix, predictions, labels):
+        correct = tf.equal(predictions, labels)
+
+        # Mask inactive timesteps
+        correct = tf.multiply(self.mask, tf.cast(correct, tf.float32))
+
+        # Compensate for inactive time steps.
+        correct = tf.reshape(correct, [-1])
+        correct = tf.truediv(correct, tf.reduce_mean(self.mask))
+
+        return tf.reduce_mean(correct, name="%s_accuracy" % prefix)
+
+
+    def masked_softmax_loss(self, prefix, logits, labels, mask):
+        # Compute losses
+        losses = tf.nn.sparse_softmax_cross_entropy_with_logits(
+            logits=logits, labels=labels)
+
+        # Mask inactive time steps.
+        losses = tf.multiply(mask, losses)
+
+        # Compensate for inactive time steps.
+        losses = tf.truediv(losses, tf.reduce_mean(mask))
+
+        # Compute sequence probabilities
+        #losses = tf.reduce_sum(losses, axis=1)
+
+        return tf.reduce_mean(losses, name="%s_loss" % prefix)
+
+    def crf_loss(self, prefix, logits, labels):
+        with tf.variable_scope("%s_crf" % prefix):
+            (loss, transitions) = tf.contrib.crf.crf_log_likelihood(
+                logits, labels, self.seq_lens)
+        return tf.reduce_mean(-loss, name="%s_loss" % prefix), transitions
+
+    def crf_predictions(self, prefix, logits, transitions):
+        predictions, _ = tf.contrib.crf.crf_decode(
+            logits, transitions, self.seq_lens)
+        return tf.identity(predictions, name="%s_predictions" % prefix)
+
+    def predictions(self, prefix, logits):
+        return tf.cast(
+            tf.argmax(
+                logits,
+                axis=2),
+            tf.int32, name="%s_predictions" % prefix)
+
+    def setup_placeholders(self):
+        self._is_training = tf.placeholder(tf.bool, [], "is_training")
+
+        self._topo_labels = tf.placeholder(
+            tf.int32, name="topo_labels", shape=[
+                None, None])
+
+        self._tokens = tf.placeholder(
+            tf.float32,
+            shape=[
+                None,
+                None,
+                self.shapes['token_embed_dims']],
+            name="tokens")
+        self._tags = tf.placeholder(
+            tf.float32, [
+                None, None, self.shapes['tag_embed_dims']], name="tags")
+
+        self._seq_lens = tf.placeholder(
+            tf.int32, [None], name="seq_lens")
+
+        # Compute mask
+        self._mask = tf.sequence_mask(
+            self.seq_lens, maxlen=tf.shape(
+                self.tags)[1], dtype=tf.float32)
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def is_training(self):
+        return self._is_training
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @property
+    def pos_labels(self):
+        return self._pos_labels
+
+    @property
+    def seq_lens(self):
+        return self._seq_lens
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @property
+    def tokens(self):
+        return self._tokens
+
+    @property
+    def topo_labels(self):
+        return self._topo_labels
+
+    @property
+    def shapes(self):
+        return self._shapes

--- a/toponn-utils/tensorflow/rnn_model.py
+++ b/toponn-utils/tensorflow/rnn_model.py
@@ -3,17 +3,7 @@
 import tensorflow as tf
 from tensorflow.contrib.layers import batch_norm
 from enum import Enum
-
-
-class Phase(Enum):
-    train = 1
-    validation = 2
-    predict = 3
-
-
-class Layer(Enum):
-    token = 1
-    tag = 2
+from model import Model
 
 
 def dropout_wrapper(cell, is_training, keep_prob):
@@ -61,29 +51,16 @@ def rnn_layers(
         sequence_length=seq_lens)
 
 
-class RNNModel:
+class RNNModel(Model):
     def __init__(
             self,
             config,
             shapes):
-        # Are we training or not?
-        self._is_training = tf.placeholder(tf.bool, [], "is_training")
+        super(RNNModel, self).__init__(config, shapes)
 
-        self._labels = tf.placeholder(
-            tf.int32, name="labels", shape=[
-                None, None])
+        self.setup_placeholders()
 
-        # Inputs: tags and tokens.
-        self._tokens = tf.placeholder(
-            tf.float32, [
-                None, None, shapes['token_embed_dims']], name="tokens")
-        self._tags = tf.placeholder(
-            tf.float32, [
-                None, None, shapes['tag_embed_dims']], name="tags")
-        self._seq_lens = tf.placeholder(
-            tf.int32, [None], name="seq_lens")
-
-        inputs = tf.concat([self._tokens, self._tags], axis=2)
+        inputs = tf.concat([self.tokens, self.tags], axis=2)
 
         inputs = tf.contrib.layers.dropout(
             inputs,
@@ -105,8 +82,6 @@ class RNNModel:
                                       output_dropout=config.keep_prob,
                                       state_dropout=config.keep_prob, seq_lens=self._seq_lens)
 
-        hidden_states = tf.reshape(hidden_states, [-1, config.hidden_size])
-
         hidden_states = batch_norm(
             hidden_states,
             decay=0.98,
@@ -115,97 +90,19 @@ class RNNModel:
             fused=False,
             updates_collections=None)
 
-        softmax_w = tf.get_variable(
-            "softmax_w", [
-                config.hidden_size, shapes['n_labels']])
-        softmax_b = tf.get_variable("softmax_b", [shapes['n_labels']])
-        logits = tf.nn.xw_plus_b(
-            hidden_states,
-            softmax_w,
-            softmax_b,
-            name="logits")
+        topo_logits = tf.layers.dense(hidden_states, shapes['n_labels'], use_bias=True, name="topo_logits")
+        if config.crf:
+            topo_loss, transitions = self.crf_loss(
+                "topo", topo_logits, self.topo_labels)
+            topo_predictions = self.crf_predictions(
+                "topo", topo_logits, transitions)
+        else:
+            topo_loss = self.masked_softmax_loss(
+                "topo", topo_logits, self.topo_labels, self.mask)
+            topo_predictions = self.predictions("topo", topo_logits)
 
-        logits = tf.reshape(
-            logits, [
-                tf.shape(self.tokens)[0], -1, shapes['n_labels']])
-
-        input_mask = tf.sequence_mask(
-            self._seq_lens, maxlen=tf.shape(
-                self._labels)[1], dtype=tf.float32)
-
-        losses = tf.nn.sparse_softmax_cross_entropy_with_logits(
-            logits=logits, labels=self._labels)
-
-        # Zero out losses for inactive steps.
-        losses = tf.multiply(input_mask, losses)
-
-        # Compensate for padded losses.
-        losses = tf.reshape(losses, [-1])
-        losses = tf.truediv(losses, tf.reduce_mean(input_mask))
-
-        self._loss = loss = tf.reduce_mean(losses, name="loss")
-
-        predicted = tf.cast(
-            tf.argmax(
-                logits,
-                axis=2),
-            tf.int32, name="predicted")
-
-        correct = tf.equal(predicted, self._labels)
-
-        # Zero out correctness for inactive steps.
-        correct = tf.multiply(input_mask, tf.cast(correct, tf.float32))
-
-        # Compensate for inactive steps
-        correct = tf.reshape(correct, [-1])
-        correct = tf.truediv(correct, tf.reduce_mean(input_mask))
-
-        self._accuracy = tf.reduce_mean(correct, name="accuracy")
+        self.accuracy("topo", topo_predictions, self.topo_labels)
 
         lr = tf.placeholder(tf.float32, [], "lr")
         self._train_op = tf.train.AdamOptimizer(
-            lr).minimize(loss, name="train")
-
-    @property
-    def accuracy(self):
-        return self._accuracy
-
-    @property
-    def correct(self):
-        return self._correct
-
-    @property
-    def is_training(self):
-        return self._is_training
-
-    @property
-    def loss(self):
-        return self._loss
-
-    @property
-    def train_op(self):
-        return self._train_op
-
-    @property
-    def labels(self):
-        return self._labels
-
-    @property
-    def tag_embeds(self):
-        return self._tag_embeds
-
-    @property
-    def tags(self):
-        return self._tags
-
-    @property
-    def tokens(self):
-        return self._tokens
-
-    @property
-    def token_embeds(self):
-        return self._token_embeds
-
-    @property
-    def seq_lens(self):
-        return self._seq_lens
+            lr).minimize(topo_loss, name="train")

--- a/toponn-utils/tensorflow/write-graph
+++ b/toponn-utils/tensorflow/write-graph
@@ -51,6 +51,10 @@ if __name__ == '__main__':
         type=str,
         help='output graph file')
     parser.add_argument(
+        "--crf",
+        help="use CRF layer for classification",
+        action="store_true")
+    parser.add_argument(
         "--glu",
         help="use GLU activiation in convolutions",
         action="store_true")
@@ -88,6 +92,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     config = DefaultConfig()
+    config.crf = args.crf
     config.glu = args.glu
     config.hidden_size = args.hidden_size
     config.keep_prob = args.keep_prob
@@ -96,12 +101,12 @@ if __name__ == '__main__':
     config.n_levels = args.levels
 
     if args.type == 'rnn':
-        print("Model: rnn")
+        print("Model: rnn, crf: %r" % config.crf)
         model = RNNModel
     elif args.type == 'conv':
         model = ConvModel
-        print("Model: convolution, kernel: %d, levels: %d, glu: %r" %
-              (config.kernel_size, config.n_levels, config.glu))
+        print("Model: convolution, kernel: %d, levels: %d, glu: %r, crf: %r" %
+              (config.kernel_size, config.n_levels, config.glu, config.crf))
     else:
         raise "Unknown model type: %s" % config.type
 


### PR DESCRIPTION
The placeholders, classification layers, loss, and accuracy computations
are shared between models. Add a Model base class with methods to create
these ops and use then in the rnn and convolution models.

This change also adds a CRF classification layer, since is was easy to
add with this refactoring. Unfortunately, in pure topological field
labling the use of CRFs does not improve accuracy.