### PR TITLE
Reduce average batch sequence lengths.

### DIFF
--- a/toponn-utils/src/bin/toponn-tag.rs
+++ b/toponn-utils/src/bin/toponn-tag.rs
@@ -94,7 +94,12 @@ fn main() {
     )
     .or_exit("Cannot load computation graph", 1);
 
-    let mut sent_proc = SentProcessor::new(tagger, writer, config.model.batch_size);
+    let mut sent_proc = SentProcessor::new(
+        tagger,
+        writer,
+        config.model.batch_size,
+        config.labeler.read_ahead,
+    );
 
     for sentence in reader.sentences() {
         let sentence = sentence.or_exit("Cannot parse sentence", 1);
@@ -114,7 +119,8 @@ where
     tagger: T,
     writer: conllx::Writer<W>,
     batch_size: usize,
-    batch_sents: Vec<Sentence>,
+    read_ahead: usize,
+    buffer: Vec<Sentence>,
 }
 
 impl<T, W> SentProcessor<T, W>
@@ -122,49 +128,72 @@ where
     T: Tag,
     W: Write,
 {
-    pub fn new(tagger: T, writer: conllx::Writer<W>, batch_size: usize) -> Self {
+    pub fn new(tagger: T, writer: conllx::Writer<W>, batch_size: usize, read_ahead: usize) -> Self {
+        assert!(batch_size > 0, "Batch size should at least be 1.");
+        assert!(read_ahead > 0, "Read ahead should at least be 1.");
+
         SentProcessor {
             tagger,
             writer,
             batch_size,
-            batch_sents: Vec::new(),
+            read_ahead,
+            buffer: Vec::with_capacity(read_ahead * batch_size),
         }
     }
 
     pub fn process(&mut self, sent: Sentence) -> Result<(), Error> {
-        self.batch_sents.push(sent);
+        self.buffer.push(sent);
 
-        if self.batch_sents.len() == self.batch_size {
-            let labels = labels_to_owned(self.tagger.tag_sentences(&self.batch_sents)?);
-            self.write_sent_labels(labels)?;
-            self.batch_sents.clear();
+        if self.buffer.len() == self.batch_size * self.read_ahead {
+            self.tag_buffered_sentences()?;
         }
 
         Ok(())
     }
 
-    fn write_sent_labels(&mut self, labels: Vec<Vec<String>>) -> Result<(), Error>
+    fn tag_buffered_sentences(&mut self) -> Result<(), Error> {
+        {
+            // Sort sentences by length.
+            let mut sent_refs: Vec<_> = self.buffer.iter_mut().map(|s| s).collect();
+            sent_refs.sort_unstable_by_key(|s| s.len());
+
+            // Split in batches, tag, and merge results.
+            for batch in sent_refs.chunks_mut(self.batch_size) {
+                let labels = labels_to_owned(self.tagger.tag_sentences(batch)?);
+                Self::merge_labels(batch, labels)?;
+            }
+        }
+
+        // Write out sentences.
+        let mut sents = Vec::with_capacity(self.read_ahead * self.batch_size);
+        std::mem::swap(&mut sents, &mut self.buffer);
+        for sent in sents {
+            self.writer.write_sentence(&sent)?;
+        }
+
+        Ok(())
+    }
+
+    fn merge_labels(sentences: &mut [&mut Sentence], labels: Vec<Vec<String>>) -> Result<(), Error>
     where
         W: Write,
     {
-        for (tokens, sent_labels) in self.batch_sents.iter_mut().zip(labels.iter()) {
+        for (tokens, sent_labels) in sentences.iter_mut().zip(labels) {
             {
-                for i in 0..tokens.len() {
+                for (token, label) in tokens.iter_mut().zip(sent_labels) {
                     // Obtain the feature mapping or construct a fresh one.
-                    let mut features = tokens[i]
+                    let mut features = token
                         .features()
                         .map(Features::as_map)
                         .cloned()
                         .unwrap_or(BTreeMap::new());
 
                     // Insert the topological field.
-                    features.insert(String::from("tf"), Some(sent_labels[i].to_owned()));
+                    features.insert(String::from("tf"), Some(label));
 
-                    tokens[i].set_features(Some(Features::from_iter(features)));
+                    token.set_features(Some(Features::from_iter(features)));
                 }
             }
-
-            self.writer.write_sentence(tokens)?;
         }
 
         Ok(())
@@ -177,17 +206,9 @@ where
     W: Write,
 {
     fn drop(&mut self) {
-        if !self.batch_sents.is_empty() {
-            let labels = labels_to_owned(match self.tagger.tag_sentences(&self.batch_sents) {
-                Ok(labels) => labels,
-                Err(err) => {
-                    eprintln!("Error tagging sentences: {}", err);
-                    return;
-                }
-            });
-
-            if let Err(err) = self.write_sent_labels(labels) {
-                eprintln!("Error writing sentences: {}", err);
+        if !self.buffer.is_empty() {
+            if let Err(err) = self.tag_buffered_sentences() {
+                eprintln!("Error tagging sentences: {}", err);
             }
         }
     }

--- a/toponn-utils/src/config.rs
+++ b/toponn-utils/src/config.rs
@@ -101,6 +101,7 @@ impl Embeddings {
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Labeler {
     pub labels: String,
+    pub read_ahead: usize,
 }
 
 fn relativize_path(config_path: &Path, filename: &str) -> Result<String, Error> {

--- a/toponn-utils/src/config_tests.rs
+++ b/toponn-utils/src/config_tests.rs
@@ -9,6 +9,7 @@ lazy_static! {
     static ref BASIC_LABELER_CHECK: Config = Config {
         labeler: Labeler {
             labels: "topo.labels".to_owned(),
+            read_ahead: 10,
         },
         embeddings: Embeddings {
             word: Embedding::Word2Vec {

--- a/toponn-utils/testdata/topo.conf
+++ b/toponn-utils/testdata/topo.conf
@@ -1,5 +1,6 @@
 [labeler]
-labels = "topo.labels"
+  labels = "topo.labels"
+  read_ahead = 10
 
 [embeddings]
   [embeddings.word]

--- a/toponn/src/tag.rs
+++ b/toponn/src/tag.rs
@@ -4,7 +4,10 @@ use failure::Error;
 
 /// Trait for topological field taggers.
 pub trait Tag {
-    fn tag_sentences(&mut self, sentences: &[Sentence]) -> Result<Vec<Vec<&str>>, Error>;
+    fn tag_sentences(
+        &mut self,
+        sentences: &[impl AsRef<Sentence>],
+    ) -> Result<Vec<Vec<&str>>, Error>;
 }
 
 /// Results of validation.

--- a/toponn/src/tensorflow/tagger.rs
+++ b/toponn/src/tensorflow/tagger.rs
@@ -323,9 +323,16 @@ impl Tagger {
 }
 
 impl Tag for Tagger {
-    fn tag_sentences(&mut self, sentences: &[Sentence]) -> Result<Vec<Vec<&str>>, Error> {
+    fn tag_sentences(
+        &mut self,
+        sentences: &[impl AsRef<Sentence>],
+    ) -> Result<Vec<Vec<&str>>, Error> {
         // Find maximum sentence size.
-        let max_seq_len = sentences.iter().map(|s| s.len()).max().unwrap_or(0);
+        let max_seq_len = sentences
+            .iter()
+            .map(|s| s.as_ref().len())
+            .max()
+            .unwrap_or(0);
 
         let (token_dims, tag_dims) = {
             let embeddings = self.vectorizer.layer_embeddings();
@@ -339,7 +346,7 @@ impl Tag for Tagger {
 
         // Fill the batch.
         for sentence in sentences {
-            let input = self.vectorizer.realize(sentence)?;
+            let input = self.vectorizer.realize(sentence.as_ref())?;
             builder.add(&input);
         }
 
@@ -351,7 +358,7 @@ impl Tag for Tagger {
         let numberer = &self.labels;
         let mut labels = Vec::new();
         for (idx, sentence) in sentences.iter().enumerate() {
-            let seq_len = min(max_seq_len, sentence.len());
+            let seq_len = min(max_seq_len, sentence.as_ref().len());
             let offset = idx * max_seq_len;
             let seq = &tag_tensor[offset..offset + seq_len];
 


### PR DESCRIPTION
The running time of a batch is proportional to the batch size and the number
of time steps in a batch. The number of timesteps is determined by the
longest sequence in the batch. Consequently, for most sequences we are
processing (a substantial) amount of padding.

The amount of (superfluous) processing of padding is minimized by minimizing
the variance of sequence lengths within a batch. This change reduces the
length variance by:

1. Reading ahead for N batches;
2. sorting the sequences by length; and
3. batching the length-sorted sequences.

In experiments on TüBa-D/Z a readahead of 10 results in a 3x reduction of
processing time.

**Footnotes:**

1. I think this can be factored out to `toponn` in the future, to make this reusable for users of toponn as a library. But I want to think a bit more about what traits would work well with these.
2. There are some forces scopes to appease the borrows checker. Should not be necessary anymore once I convert this project to Rust 2018 due to NLL.